### PR TITLE
Provide a filter parameter

### DIFF
--- a/PoshMongo/GetDocument.cs
+++ b/PoshMongo/GetDocument.cs
@@ -1,5 +1,6 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Driver;
+using System.Collections;
 using System.Management.Automation;
 
 namespace PoshMongo
@@ -7,23 +8,39 @@ namespace PoshMongo
     [Cmdlet(VerbsCommon.Get, "Document")]
     public class GetDocument : PSCmdlet
     {
-        [Parameter(Mandatory = false, Position = 0, ParameterSetName = "Default")]
+        [Parameter(Mandatory = false, Position = 0)]
         public string? DocumentId { get; set; }
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = "Filter")]
+        public Hashtable? Filter { get; set; }
         protected override void BeginProcessing()
         {
             IMongoCollection<BsonDocument> Collection = (IMongoCollection<BsonDocument>)SessionState.PSVariable.Get("Collection").Value;
             BsonDocument bsonDocument = new();
-            if (!(string.IsNullOrEmpty(DocumentId)))
+            switch (ParameterSetName)
             {
-                FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.Eq("_id", DocumentId);
-                WriteObject(Collection.Find(filter).FirstOrDefault().ToJson());
-            }
-            else
-            {
-                foreach (BsonDocument document in Collection.Find(bsonDocument).ToList())
-                {
-                    WriteObject(document.ToJson());
-                }
+                case "Filter":
+                    List<FilterDefinition<BsonDocument>> filters = new List<FilterDefinition<BsonDocument>>();
+                    foreach (string key in Filter.Keys)
+                    {
+                        filters.Add(Builders<BsonDocument>.Filter.Eq(key, Filter[key]));
+                    }
+                    FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.And(filters);
+                    WriteObject(Collection.Find(filter).FirstOrDefault().ToJson());
+                    break;
+                default:
+                    if (!(string.IsNullOrEmpty(DocumentId)))
+                    {
+                        FilterDefinition<BsonDocument> id = Builders<BsonDocument>.Filter.Eq("_id", DocumentId);
+                        WriteObject(Collection.Find(id).FirstOrDefault().ToJson());
+                    }
+                    else
+                    {
+                        foreach (BsonDocument document in Collection.Find(bsonDocument).ToList())
+                        {
+                            WriteObject(document.ToJson());
+                        }
+                    }
+                    break;
             }
         }
     }

--- a/PoshMongo/GetDocument.cs
+++ b/PoshMongo/GetDocument.cs
@@ -19,13 +19,16 @@ namespace PoshMongo
             switch (ParameterSetName)
             {
                 case "Filter":
-                    List<FilterDefinition<BsonDocument>> filters = new List<FilterDefinition<BsonDocument>>();
-                    foreach (string key in Filter.Keys)
+                    if (!(Filter == null))
                     {
-                        filters.Add(Builders<BsonDocument>.Filter.Eq(key, Filter[key]));
+                        List<FilterDefinition<BsonDocument>> filters = new List<FilterDefinition<BsonDocument>>();
+                        foreach (string key in Filter.Keys)
+                        {
+                            filters.Add(Builders<BsonDocument>.Filter.Eq(key, Filter[key]));
+                        }
+                        FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.And(filters);
+                        WriteObject(Collection.Find(filter).FirstOrDefault().ToJson());
                     }
-                    FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.And(filters);
-                    WriteObject(Collection.Find(filter).FirstOrDefault().ToJson());
                     break;
                 default:
                     if (!(string.IsNullOrEmpty(DocumentId)))

--- a/PoshMongo/RemoveDocument.cs
+++ b/PoshMongo/RemoveDocument.cs
@@ -1,5 +1,6 @@
 ﻿using MongoDB.Bson;
 using MongoDB.Driver;
+using System.Collections;
 using System.Management.Automation;
 
 namespace PoshMongo
@@ -7,13 +8,33 @@ namespace PoshMongo
     [Cmdlet(VerbsCommon.Remove, "Document")]
     public class RemoveDocument : PSCmdlet
     {
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Default")]
+        [Parameter(Mandatory = true, Position = 0)]
         public string? DocumentId { get; set; }
+        [Parameter(Mandatory = false, Position = 0, ParameterSetName = "Filter")]
+        public Hashtable? Filter { get; set; }
         protected override void BeginProcessing()
         {
             IMongoCollection<BsonDocument> Collection = (IMongoCollection<BsonDocument>)SessionState.PSVariable.Get("Collection").Value;
-            FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.Eq("_id", DocumentId);
-            WriteObject(Collection.DeleteOne(filter));
+            switch (ParameterSetName)
+            {
+                case "Filter":
+                    if (!(Filter == null))
+                    {
+                        List<FilterDefinition<BsonDocument>> filters = new List<FilterDefinition<BsonDocument>>();
+                        foreach (string key in Filter.Keys)
+                        {
+                            filters.Add(Builders<BsonDocument>.Filter.Eq(key, Filter[key]));
+                        }
+                        FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.And(filters);
+                        WriteObject(Collection.Find(filter).FirstOrDefault().ToJson());
+                    }
+                    break;
+                default:
+                    FilterDefinition<BsonDocument> id = Builders<BsonDocument>.Filter.Eq("_id", DocumentId);
+                    WriteObject(Collection.DeleteOne(id));
+                    break;
+            }
+
         }
     }
 }


### PR DESCRIPTION
Add a Hashtable parameter for Filter. This change allows for a simple hashtable filter to be passed into the cmdlet. Currently this only supports a very basic filter.

```powershell
@{'_id'='123';'Name'='MyName'}
```

Is translated loosely into

```csharp
Builders<BsonDocument>.Filter.Eq("_id", Value)
Builders<BsonDocument>.Filter.Eq("Name", Value)
```