### PR TITLE
14 removecollectioncmdlet should use the namespace in deletes

### DIFF
--- a/Docs/Remove-MongoDBCollection.md
+++ b/Docs/Remove-MongoDBCollection.md
@@ -122,7 +122,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
-### MongoDB.Driver.IMongoCollection
+### null
 
 ## NOTES
 

--- a/PoshMongo.psd1
+++ b/PoshMongo.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PoshMongo.dll'
 
 # Version number of this module.
-ModuleVersion = '2.4.1'
+ModuleVersion = '2.4.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/Tests/Remove-MongoDBCollection.Tests.ps1
+++ b/Tests/Remove-MongoDBCollection.Tests.ps1
@@ -52,8 +52,8 @@ Describe "Remove-MongoDBCollection" -Tag "PoshMongo", "RemoveCollectionCmdlet", 
  Context "Remove-MongoDBCollection Usage" {
   Context "Remove-MongoDBCollection CollectionName ParameterSet" {
    Context "With a CollectionName" {
-    It "Should Return MongoDB.Driver.IMongoCollection" {
-     (Remove-MongoDBCollection -CollectionName 'myCollection1').GetType().FullName | Should -Be 'System.Collections.Generic.List`1[[MongoDB.Driver.IMongoCollection`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.18.0.0, Culture=neutral, PublicKeyToken=null]], MongoDB.Driver, Version=2.18.0.0, Culture=neutral, PublicKeyToken=null]]'
+    It "Should Return null" {
+     Remove-MongoDBCollection -CollectionName 'myCollection1' | Should -Be $null
     }
    }
    Context "Without a CollectionName" {
@@ -79,8 +79,8 @@ Describe "Remove-MongoDBCollection" -Tag "PoshMongo", "RemoveCollectionCmdlet", 
   }
   Context "Remove-MongoDBCollection DatabaseName ParameterSet" {
    Context "With a DatabaseName" {
-    It "Should Return MongoDB.Driver.IMongoCollection" {
-     (Remove-MongoDBCollection -DatabaseName 'MyDB1' -CollectionName 'myCollection2').GetType().FullName | Should -Be 'System.Collections.Generic.List`1[[MongoDB.Driver.IMongoCollection`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.18.0.0, Culture=neutral, PublicKeyToken=null]], MongoDB.Driver, Version=2.18.0.0, Culture=neutral, PublicKeyToken=null]]'
+    It "Should Return null" {
+     Remove-MongoDBCollection -DatabaseName 'MyDB1' -CollectionName 'myCollection2' | Should -Be $null
     }
    }
    Context "Without a DatabaseName" {
@@ -106,8 +106,8 @@ Describe "Remove-MongoDBCollection" -Tag "PoshMongo", "RemoveCollectionCmdlet", 
   }
   Context "Remove-MongoDBCollection Collection ParameterSet" {
    Context "With a Collection" {
-    It "Should Return MongoDB.Driver.IMongoCollection" {
-     (Remove-MongoDBCollection -Collection (Get-MongoDBCollection -CollectionName 'myCollection3') ).GetType().FullName | Should -Be 'System.Collections.Generic.List`1[[MongoDB.Driver.IMongoCollection`1[[MongoDB.Bson.BsonDocument, MongoDB.Bson, Version=2.18.0.0, Culture=neutral, PublicKeyToken=null]], MongoDB.Driver, Version=2.18.0.0, Culture=neutral, PublicKeyToken=null]]'
+    It "Should Return null" {
+     Remove-MongoDBCollection -Collection (Get-MongoDBCollection -CollectionName 'myCollection3') | Should -Be $null
     }
    }
    Context "Without a Collection" {


### PR DESCRIPTION
Updated cmdlet to use the CollectionNamespace when passed in a collection to remove. Also fixed cmdlet to return null, instead of a list of remaining collections.