### PR TITLE
Issue-#34: AddDocument changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All changes to this module should be reflected in this document.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[3.3.0]](https://github.com/PoshMongo/PoshMongo/releases/tag/v3.3.0) - 2022-12-14
+
+These changes allow the PowerShell cmdlet to leverage the `-Force` parameter to control upsert behavior when adding documents to a MongoDB collection.
+
+### Operations Class
+
+1. **Method Enhancement**:
+   - Enhanced the `AddDocument` method to accept an additional boolean parameter for upsert functionality (`isUpsert`).
+
+2. **Upsert Logic**:
+   - Incorporated logic to replace an existing document if `isUpsert` is true, otherwise, it performs a standard insert.
+
+#### Cmdlet Class
+
+1. **Force Parameter Addition**:
+   - Added a `Force` parameter to the cmdlet, enabling users to specify whether the document should be upserted.
+
+2. **Determine Upsert Based on Force**:
+   - Used the presence of the `Force` switch to determine the value of the `isUpsert` parameter.
+
+3. **Integration with Operations Class**:
+   - Passed the determined `isUpsert` value from the cmdlet to the `AddDocument` method in the `Operations` class.
+
+--
+
 ## [[3.2.1]](https://github.com/PoshMongo/PoshMongo/releases/tag/v3.2.1) - 2022-12-14
 
 This is a minor release to fix the Update-Help issue #25. The Manifest was missing the HelpInfoUri, and the HelpInfo.xml is generated based on values in the PoshMongo.md file. This file had an incorrect download location so this has been updated.

--- a/PoshMongo.psd1
+++ b/PoshMongo.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PoshMongo.dll'
 
 # Version number of this module.
-ModuleVersion = '3.2.1'
+ModuleVersion = '3.3.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PoshMongo/AddDocument.cs
+++ b/PoshMongo/AddDocument.cs
@@ -19,6 +19,8 @@ namespace PoshMongo.Document
         public string DatabaseName { get; set; } = string.Empty;
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "Collection", ValueFromPipeline = true)]
         public IMongoCollection<BsonDocument>? MongoCollection { get; set; } = null;
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Force { get; set; }
         private IMongoDatabase? MongoDatabase { get; set; } = null;
         private IMongoClient? Client { get; set; } = null;
         protected override void BeginProcessing()
@@ -32,18 +34,19 @@ namespace PoshMongo.Document
         }
         protected override void ProcessRecord()
         {
+            bool isUpsert = Force.IsPresent;
             switch (ParameterSetName)
             {
                 case "CollectionName":
                     if (MongoCollection != null)
                     {
-                        WriteObject(Operations.AddDocument(MongoCollection, Document));
+                        WriteObject(Operations.AddDocument(MongoCollection, Document, isUpsert));
                     }
                     break;
                 case "Collection":
                     if (MongoCollection != null)
                     {
-                        WriteObject(Operations.AddDocument(MongoCollection, Document));
+                        WriteObject(Operations.AddDocument(MongoCollection, Document, isUpsert));
                     }
                     break;
             }

--- a/PoshMongo/GetDocument.cs
+++ b/PoshMongo/GetDocument.cs
@@ -47,7 +47,7 @@ namespace PoshMongo.Document
         public SwitchParameter List { get; set; }
         private IMongoDatabase? MongoDatabase { get; set; } = null;
         private IMongoClient? Client { get; set; } = null;
-        private FilterDefinition<BsonDocument> BFilter { get; set; }
+        private FilterDefinition<BsonDocument>? BFilter { get; set; }
         protected override void BeginProcessing()
         {
             Client = (IMongoClient)SessionState.PSVariable.Get("Client").Value;

--- a/PoshMongo/Operations.cs
+++ b/PoshMongo/Operations.cs
@@ -21,20 +21,30 @@ namespace PoshMongo
         /// </summary>
         /// <param name="Collection">The collection to add the document to</param>
         /// <param name="document">A json string document</param>
+        /// <param name="isUpsert">Boolean to indicate if upsert should be performed</param>
         /// <returns></returns>
-        public static string AddDocument(IMongoCollection<BsonDocument> Collection, string document)
+        public static string AddDocument(IMongoCollection<BsonDocument> Collection, string document, bool isUpsert)
         {
             BsonDocument bsonDocument = BsonDocument.Parse(document);
-            Collection.InsertOne(bsonDocument);
             FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.Eq("_id", bsonDocument["_id"]);
+
+            if (isUpsert)
+            {
+                ReplaceOptions options = new ReplaceOptions { IsUpsert = true };
+                Collection.ReplaceOne(filter, bsonDocument, options);
+            }
+            else
+            {
+                Collection.InsertOne(bsonDocument);
+            }
+
             return Collection.Find(filter).FirstOrDefault().ToJson();
-        }
-        /// <summary>
-        /// Create a Collection in a MongoDatabase
-        /// </summary>
-        /// <param name="collectionName">The name of the Collection to create</param>
-        /// <param name="mongoDatabase">The MongoDatabase to create the Collection in</param>
-        /// <returns></returns>
+        }        /// <summary>
+                 /// Create a Collection in a MongoDatabase
+                 /// </summary>
+                 /// <param name="collectionName">The name of the Collection to create</param>
+                 /// <param name="mongoDatabase">The MongoDatabase to create the Collection in</param>
+                 /// <returns></returns>
         public static IMongoCollection<BsonDocument> NewCollection(string collectionName, IMongoDatabase mongoDatabase)
         {
             mongoDatabase.CreateCollection(collectionName, new CreateCollectionOptions(), new CancellationToken());

--- a/PoshMongo/PoshMongo.csproj
+++ b/PoshMongo/PoshMongo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Title>PoshMongo</Title>
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.18.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
-    <PackageReference Include="MongoDB.Driver.Core" Version="2.18.0" />
+    <PackageReference Include="MongoDB.Bson" Version="2.27.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
+    <PackageReference Include="MongoDB.Driver.Core" Version="2.27.0" />
     <PackageReference Include="System.Management.Automation" Version="7.2.7" />
   </ItemGroup>
 

--- a/psakefile.ps1
+++ b/psakefile.ps1
@@ -77,7 +77,7 @@ Task CleanModuleDirectory -Description "Clean the module directory" -Action {
 }
 
 Task CopyModuleFiles -Description "Copy files for the module" -Action {
- Copy-Item .\PoshMongo\bin\Release\net6.0\*.dll Module -Force
+ Copy-Item .\PoshMongo\bin\Release\net7.0\*.dll Module -Force
  Copy-Item .\PoshMongo.psd1 Module -Force
 }
 


### PR DESCRIPTION
### Summary of Changes

#### Operations Class

1. **Method Enhancement**:
   - Enhanced the `AddDocument` method to accept an additional boolean parameter for upsert functionality (`isUpsert`).

2. **Upsert Logic**:
   - Incorporated logic to replace an existing document if `isUpsert` is true, otherwise, it performs a standard insert.

#### Cmdlet Class

1. **Force Parameter Addition**:
   - Added a `Force` parameter to the cmdlet, enabling users to specify whether the document should be upserted.

2. **Determine Upsert Based on Force**:
   - Used the presence of the `Force` switch to determine the value of the `isUpsert` parameter.

3. **Integration with Operations Class**:
   - Passed the determined `isUpsert` value from the cmdlet to the `AddDocument` method in the `Operations` class.

These changes allow the PowerShell cmdlet to leverage the `-Force` parameter to control upsert behavior when adding documents to a MongoDB collection.